### PR TITLE
Change Replacement Indexing

### DIFF
--- a/amplify/functions/remove/handler.ts
+++ b/amplify/functions/remove/handler.ts
@@ -9,6 +9,9 @@ export const handler: Schema["removePersonalInfo"]["functionHandler"] = async (e
     try {   
 
         const entities: PiiEntity[] = await detectPiiEntities(message)
+
+        console.log("Entities: ", entities)
+
         message = await removeDetections(message, entities)
 
         return { content: message }


### PR DESCRIPTION
1. Now map similar entity types rather than words
2. Push array of detected words and their indexes
3. Use this map to make replacements and properly name replacement variables